### PR TITLE
Update _responsive.less

### DIFF
--- a/less/_responsive.less
+++ b/less/_responsive.less
@@ -23,6 +23,27 @@
   .board {
     padding: 0 10px 50px;
   }
+  .page-nav-item_active {
+  opacity:1;
+  }
+  .page-nav-bottom i {
+  margin-top: 0;
+  top:40px;
+  left:45%;
+  position:fixed;
+  opacity:1;
+  }
+  .page-nav-top i {
+  margin-top: 0;
+  top:40px;
+  left:55%;
+  position:fixed;
+  }
+  .page-nav {
+  opacity:0.6;
+  width: 0;
+  z-index:1;
+  }
 }
 
 // Mobile.
@@ -103,27 +124,6 @@
   }
   .post-file-thumb, .post-file-link {
   display: inline-block;
-  }
-  .page-nav-item_active {
-  opacity:1;
-  }
-  .page-nav-bottom i {
-  margin-top: 0;
-  top:40px;
-  left:45%;
-  position:fixed;
-  opacity:1;
-  }
-  .page-nav-top i {
-  margin-top: 0;
-  top:40px;
-  left:55%;
-  position:fixed;
-  }
-  .page-nav {
-  opacity:0.6;
-  width: 0;
-  z-index:1;
   }
   .reply-send-button {
   width: 90px;


### PR DESCRIPTION
Moves page-nav bar responsive changes from 480px to 768px @media because without the .board padding active, the page nav is in the way and makes clicking small spoilers, delete-post and ban-post buttons impossible on tablets and zoomed in vertical monitors