### PR TITLE
Adding 2 custom events to support userscripts better

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -49,10 +49,13 @@ async function init() {
       initPosts();
     }
   }
-
+  
   initUI();
   initAuth();
   initProfiles();
+
+  // Fire off site fully loaded event for userscripts
+  document.dispatchEvent(new CustomEvent('site_fully_loaded', {bubbles:true}));
 }
 
 init().catch((err) => {

--- a/ts/client/index.ts
+++ b/ts/client/index.ts
@@ -42,6 +42,9 @@ export function insertPost(data: PostData) {
   if (options.scrollToBottom && atBottom && !isHoverActive()) {
     scrollToBottom();
   }
+  // Fire event to signal userscripts that a new post was added
+  document.dispatchEvent(new CustomEvent('new_post_hook', {bubbles:true,
+    detail: {post: view.el}}));
 }
 
 export function init() {


### PR DESCRIPTION

![Screenshot 2021-05-29 103225](https://user-images.githubusercontent.com/38842440/120065531-09e8f980-c072-11eb-8657-c57299948d84.jpg)
new_post_hook
-fires 1 event with the new post element for every new post that a user receives. Very useful so userscripts that want to manipulate new posts don't have to mess around with mutationobserver.

site_fully_loaded
-event fires one time when the site fully loaded and finished all js. currently the usual methods to wait for the site to finish loading dont work on kch. for example the (You)s get added after the DOMloaded signal is already sent. I think currently the only way is to set a shitty timer for the script to wait.

There are 4 userscripts that I know of in use right now which could benefit from these 2 events